### PR TITLE
Upgrade DMN core to v1.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7508,8 +7508,8 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-model-navigator": {
-      "version": "1.2.2",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#14b03bd6d5af3d3b2895f3be6bd0f4c37f4537c8",
+      "version": "1.2.3",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#2536845ba698e2507e1070caf14cc4793c6926f0",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",


### PR DESCRIPTION
Upgrade model navigator package to 1.2.3 to fix link targeting the current tab instead of a new one.